### PR TITLE
Enable dark theme switch

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -1,5 +1,6 @@
 template:
   bootstrap: 5
+  light-switch: true
 
 home:
   sidebar:


### PR DESCRIPTION
Context: https://www.tidyverse.org/blog/2024/07/pkgdown-2-1-0/#light-switch

pkgdown now natively supports the light-/dark-theme switch functionality that was previously supported by preferably but abandoned because of instability.

![image](https://github.com/user-attachments/assets/c7271820-e725-45d8-bedb-4b356ad81e7f)
